### PR TITLE
Fix error if the world does not exist in dynmap.worlds

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,10 @@ export type Unarray<T> = T extends readonly (infer P)[] ? P : T;
 
 export function getMapForDimension(dimension: string, dynmap: DynMap, config: IConfig) {
   const worldName = Object.entries(config.worlds).find(([_, v]) => v == dimension)?.[0];
-  const world = worldName ? dynmap.worlds[worldName] : null;
-  return world.maps[dynmap.maptype.options.name] ?? world.maps[Object.keys(world.maps)[0]];
+  if (worldName && Reflect.has(dynmap.worlds, worldName)) {
+    const world = dynmap.worlds[worldName];
+    return world.maps[dynmap.maptype.options.name] ?? world.maps[Object.keys(world.maps)[0]];
+  } else {
+    return null
+  }
 }


### PR DESCRIPTION
I removed DIM-1 from the map with an error case similar to #8.

Please note that the code is not fully tested; there may be other problems.

In my case, the problem has been fixed.

![image](https://github.com/user-attachments/assets/8b396592-e945-457d-9775-ca1332924ffb)

![image](https://github.com/user-attachments/assets/1bf1c95a-1dbf-4a93-8fe6-5c6c852a44ee)
