### PR TITLE
Fix clicking trains doesn't pan

### DIFF
--- a/src/RenderManager.ts
+++ b/src/RenderManager.ts
@@ -16,6 +16,13 @@ import { SignalRenderer } from "./renderers/SignalRenderer";
 import { PortalRenderer } from "./renderers/PortalRenderer";
 import { StationRenderer } from "./renderers/StationRenderer";
 
+interface DynMapLocation {
+  world?: string;
+  x: number;
+  y: number;
+  z: number;
+}
+
 export class RenderManager {
   #streams: {
     network: Stream<NetworkAPIResponse>;
@@ -112,7 +119,12 @@ export class RenderManager {
     this.#streams.trains.onMessage((data) => {
       for (const train of data.trains) {
         const position = train.cars[0].leading;
+        const trainLocation: DynMapLocation = { ...position.location };
         const map = getMapForDimension(position.dimension, dynmap, config);
+
+        if (map?.options.world.name) {
+          trainLocation.world = map.options.world.name;
+        }
 
         let $el = $("#train-" + train.id);
         if (!$el.length) {
@@ -124,8 +136,8 @@ export class RenderManager {
         }
         $el.off();
         $el.on("click", () => {
-          if (dynmap.world.name == map?.options.world.name) dynmap.panToLocation(position.location);
-          else dynmap.selectMapAndPan(map, position.location);
+          if (dynmap.world.name == map?.options.world.name) dynmap.panToLocation(trainLocation);
+          else dynmap.selectMapAndPan(map, trainLocation);
         });
       }
     });


### PR DESCRIPTION
At least with Dynmap version: core=3.7-SNAPSHOT-949, plugin=3.7-SNAPSHOT, clicking a train in the side menu will only jump you to the train when changing dimensions. If you're already on the same dimension, the map won't move.

This is due to dynmap's `panToLocation` expecting a `world` on the location object, which this addon doesn't give.

https://github.com/webbukkit/dynmap/blob/30d6845bb233f0dce88589c221faf68e58a3e336/DynmapCore/src/main/resources/extracted/web/js/map.js#L591
